### PR TITLE
Expose a restful API for ActiveRecord resources.

### DIFF
--- a/lib/fron/active_record/model.rb
+++ b/lib/fron/active_record/model.rb
@@ -79,13 +79,24 @@ module Fron
             model.accessible_by(ability, :read).where(declared(params, include_missing: false).compact).to_a
           end
 
+        end
+
+        def rest_actions
           params { requires :id }
-          route :any, :find do
-            authorize! :read, model.find(params[:id])
+          route_param :id do
+            get do
+              authorize! :read, model.find(params[:id])
+            end
+
+            delete do
+              item = model.find(params[:id])
+              authorize! :destroy, item
+              item.destroy
+            end
           end
 
           params { use :object }
-          route :any, :create do
+          post do
             data = declared(params)
             item = model.new data
             authorize! :create, item
@@ -93,22 +104,17 @@ module Fron
             item
           end
 
-          params { requires :id }
-          route :any, :destroy do
-            item = model.find(params[:id])
-            authorize! :destroy, item
-            item.destroy
-          end
-
           params do
             use :object
             requires :id
           end
-          route :any, :update do
-            item = model.find(params[:id])
-            authorize! :update, item
-            item.update_attributes!(declared(params, include_missing: false))
-            item
+          route_param :id do
+            put do
+              item = model.find(params[:id])
+              authorize! :update, item
+              item.update_attributes!(declared(params, include_missing: false))
+              item
+            end
           end
         end
       end

--- a/opal/fron/active_record/manager.rb
+++ b/opal/fron/active_record/manager.rb
@@ -25,13 +25,13 @@ module Fron
       end
 
       def find(id)
-        request :post, '/find', id: id do |data|
+        request :get, "/#{id}" do |data|
           yield data
         end
       end
 
       def update(id, data, &block)
-        request :post, '/update', { id: id}.merge(data), &block
+        request :put, "/#{id}", data, &block
       end
 
       def update_or_create(id, data, &block)
@@ -43,11 +43,11 @@ module Fron
       end
 
       def destroy(id, &block)
-        request :post, '/destroy', { id: id}, &block
+        request :delete, "/#{id}", &block
       end
 
       def create(data)
-        request :post, '/create', data do |response|
+        request :post, '/', data do |response|
           yield response
         end
       end


### PR DESCRIPTION
By default only the where action will be exposed. To expose the other
actions, `Fron::ActiveRecord::Model.rest_actions` has to be called.
